### PR TITLE
Update Metawear-iOSAPI.podspec

### DIFF
--- a/Metawear-iOSAPI.podspec
+++ b/Metawear-iOSAPI.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "Metawear-iOSAPI"
+  s.name         = "Metawear"
   s.version      = "1.1.1"
   s.summary      = "API for iOS + documentation files for the MetaWear platform"
   s.description  = <<-DESC


### PR DESCRIPTION
Problem is that with this configuration, Cocoapods name the package Metawear-iOSAPI so you have to `#import <Metawear-iOSAPI/MetaWear.h>` and rename all the import in this file :

```
#import <Metawear-iOSAPI/MBLAccelerometer.h>
#import <Metawear-iOSAPI/MBLAccelerometerData.h>
#import <Metawear-iOSAPI/MBLConstants.h>
#import <Metawear-iOSAPI/MBLDeviceInfo.h>
#import <Metawear-iOSAPI/MBLEvent.h>
#import <Metawear-iOSAPI/MBLGPIO.h>
#import <Metawear-iOSAPI/MBLHapticBuzzer.h>
#import <Metawear-iOSAPI/MBLiBeacon.h>
#import <Metawear-iOSAPI/MBLLED.h>
#import <Metawear-iOSAPI/MBLLogEntry.h>
#import <Metawear-iOSAPI/MBLMechanicalSwitch.h>
#import <Metawear-iOSAPI/MBLMetaWear.h>
#import <Metawear-iOSAPI/MBLMetaWearManager.h>
#import <Metawear-iOSAPI/MBLNeopixel.h>
#import <Metawear-iOSAPI/MBLOrientationData.h>
#import <Metawear-iOSAPI/MBLTemperature.h>
#import <Metawear-iOSAPI/MBLTemperatureData.h>
````

Which is just a fucking mess.

So this should fix it.
Also for maintenance you should use an appropriate Pod Template, Code for Cocoapods First

Bisous